### PR TITLE
Analytics proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
 - collecting of analytic events with playback data for Kinescope dashboard
 - textField in example project to allow user to input videoId
 - ability to manage options menu on player view
+- ability to listen analytic events in `KinescopeAnalyticsDelegate`

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -191,3 +191,19 @@ To add new localization to strings from SDK, add in your project file "Kinescope
 # Error Handling
 
 KinescopePlayerView has inbox error handling logic and retry-mechanism. If video is not available or some error occured player will try to retry failed operation 10 times with 5 seconds delay between each attempt. If all attempts failed player will show error overlay with refresh button. 
+
+# Analytics
+
+KinescopePlayer automaticaly send analytic events to Kinescope dashboard. You can get access to this events by implementing `KinescopeAnalyticsDelegate` protocol and set it like below
+
+```swift
+Kinescope.shared.setAnalytics(delegate: yourDelegate)
+```
+
+In delegate you can check all playback data which we sending to Kinescope dashboard.
+
+If you want to log only events without playback data, you can intercept them using `logger`.
+
+```swift
+Kinescope.shared.set(logger: KinescopeDefaultLogger(), levels: [KinescopeLoggerLevel.analytics])
+```

--- a/Example/KinescopeExample/AppDelegate.swift
+++ b/Example/KinescopeExample/AppDelegate.swift
@@ -30,6 +30,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     private func setupSDK() {
         Kinescope.shared.setConfig(.init())
+        Kinescope.shared.setAnalytics(delegate: self)
         Kinescope.shared.set(logger: KinescopeDefaultLogger(), levels: KinescopeLoggerLevel.allCases)
     }
 
@@ -47,6 +48,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         } catch {
             Kinescope.shared.logger?.log(error: error, level: KinescopeLoggerLevel.player)
         }
+    }
+
+}
+
+extension AppDelegate: KinescopeAnalyticsDelegate {
+
+    func didSendAnalytics(event: String, with data: String) {
+        debugPrint("Catched analytic event: \(event) with data \(data)")
     }
 
 }

--- a/Sources/KinescopeSDK/Events/InnerEventsProtoHandler.swift
+++ b/Sources/KinescopeSDK/Events/InnerEventsProtoHandler.swift
@@ -73,7 +73,7 @@ private extension InnerEventsProtoHandler {
             $0.device = dataStorage.device.provide() ?? .init()
             $0.session = dataStorage.session.provide() ?? .init()
             $0.playback = dataStorage.playback.provide() ?? .init()
-            $0.eventTime = .init()
+            $0.eventTime = .init(date: Date())
             return
         }
     }

--- a/Sources/KinescopeSDK/Manager/Manager+KinescopeConfigurable.swift
+++ b/Sources/KinescopeSDK/Manager/Manager+KinescopeConfigurable.swift
@@ -22,8 +22,15 @@ extension Manager: KinescopeConfigurable {
                                                assetService: AssetNetworkService())
         self.inspector = Inspector(videosService: VideosNetworkService(transport: Transport(),
                                                                        config: config))
-        self.analyticFactory = AnalyticHandler(service: AnalyticsNetworkService(transport: Transport(), config: config))
+        self.analyticFactory = AnalyticHandler(service: AnalyticsProxyService(wrappedServices: [
+            AnalyticsNetworkService(transport: Transport(), config: config),
+            AnalyticsLoggingService()
+        ]))
 
+    }
+    
+    func setAnalytics(delegate: any KinescopeAnalyticsDelegate) {
+        Kinescope.analyticDelegate = delegate
     }
 
     func set(logger: KinescopeLogging, levels: [KinescopeLoggingLevel]) {

--- a/Sources/KinescopeSDK/Player/KinescopeVideoPlayer.swift
+++ b/Sources/KinescopeSDK/Player/KinescopeVideoPlayer.swift
@@ -139,6 +139,7 @@ public class KinescopeVideoPlayer: KinescopePlayer, KinescopePlayerBody, Fullscr
 
     public required convenience init(config: KinescopePlayerConfig) {
         self.init(config: config, dependencies: KinescopeVideoPlayerDependencies())
+        self.configureAnalytic()
     }
 
     public func play() {

--- a/Sources/KinescopeSDK/Protocols/KinescopeConfigurable.swift
+++ b/Sources/KinescopeSDK/Protocols/KinescopeConfigurable.swift
@@ -10,9 +10,12 @@ public protocol KinescopeConfigurable {
 
     /// - parameter config: Configuration parameters required to connection
     func setConfig(_ config: KinescopeConfig)
+    
+    /// - parameter delegate: Delegate to listen for analytics sended from ``KinescopeVideoPlayer``
+    func setAnalytics(delegate: KinescopeAnalyticsDelegate)
 
     /// - parameter logger: opportunity to set custom logger
     /// - parameter levels: levels of logging
     func set(logger: KinescopeLogging, levels: [KinescopeLoggingLevel])
-    
+
 }

--- a/Sources/KinescopeSDK/Service/Analytic/AnalyticsDelegate.swift
+++ b/Sources/KinescopeSDK/Service/Analytic/AnalyticsDelegate.swift
@@ -1,0 +1,17 @@
+//
+//  KinescopeAnalyticsDelegate.swift
+//  KinescopeSDK
+//
+//  Created by Nikita Korobeinikov on 02.04.2024.
+//
+
+import Foundation
+
+/// Delegate to listen for analytics sended from ``KinescopeVideoPlayer``
+public protocol KinescopeAnalyticsDelegate {
+    /// Fired when ``KinescopeVideoPlayer`` is sending any analytics `event`
+    ///  - Parameters:
+    ///     - event: name of the event
+    ///     - data: serialized data in `String` format
+    func didSendAnalytics(event: String, with data: String)
+}

--- a/Sources/KinescopeSDK/Service/Analytic/AnalyticsLoggingService.swift
+++ b/Sources/KinescopeSDK/Service/Analytic/AnalyticsLoggingService.swift
@@ -1,0 +1,18 @@
+//
+//  AnalyticsLoggingService.swift
+//  KinescopeSDK
+//
+//  Created by Nikita Korobeinikov on 02.04.2024.
+//
+
+import Foundation
+
+/// Implementation of ``AnalyticsService`` which can delegate sending to client code
+final class AnalyticsLoggingService: AnalyticsService {
+
+    func send(event: Analytics_Native) {
+        Kinescope.analyticDelegate?.didSendAnalytics(event: event.event,
+                                                     with: event.textFormatString())
+    }
+
+}

--- a/Sources/KinescopeSDK/Service/Analytic/AnalyticsNetworkService.swift
+++ b/Sources/KinescopeSDK/Service/Analytic/AnalyticsNetworkService.swift
@@ -1,16 +1,13 @@
 //
-//  AnalyticsService.swift
+//  AnalyticsNetworkService.swift
 //  KinescopeSDK
 //
-//  Created by Artemii Shabanov on 27.04.2021.
+//  Created by Nikita Korobeinikov on 02.04.2024.
 //
 
 import Foundation
 
-protocol AnalyticsService {
-    func send(event: Analytics_Native)
-}
-
+/// Implementation of ``AnalyticsService`` which will send analytic via network to kinescope dashboard
 final class AnalyticsNetworkService: AnalyticsService {
 
     // MARK: - Private Properties

--- a/Sources/KinescopeSDK/Service/Analytic/AnalyticsProxyService.swift
+++ b/Sources/KinescopeSDK/Service/Analytic/AnalyticsProxyService.swift
@@ -1,0 +1,23 @@
+//
+//  AnalyticsProxyService.swift
+//  KinescopeSDK
+//
+//  Created by Nikita Korobeinikov on 02.04.2024.
+//
+
+import Foundation
+
+/// Implementation of ``AnalyticsService`` which can delegate sending to other services
+final class AnalyticsProxyService: AnalyticsService {
+
+    private let wrappedServices: [AnalyticsService]
+
+    init(wrappedServices: [AnalyticsService]) {
+        self.wrappedServices = wrappedServices
+    }
+
+    func send(event: Analytics_Native) {
+        wrappedServices.forEach { $0.send(event: event) }
+    }
+
+}

--- a/Sources/KinescopeSDK/Service/Analytic/AnalyticsService.swift
+++ b/Sources/KinescopeSDK/Service/Analytic/AnalyticsService.swift
@@ -1,0 +1,12 @@
+//
+//  AnalyticsService.swift
+//  KinescopeSDK
+//
+//  Created by Artemii Shabanov on 27.04.2021.
+//
+
+import Foundation
+
+protocol AnalyticsService {
+    func send(event: Analytics_Native)
+}

--- a/Sources/KinescopeSDK/Shared/Kinescope.swift
+++ b/Sources/KinescopeSDK/Shared/Kinescope.swift
@@ -19,4 +19,6 @@ public enum Kinescope {
     static var analytic: KinescopeAnalyticHandlerFactory? {
         return (shared as? Manager)?.analyticFactory
     }
+
+    static var analyticDelegate: KinescopeAnalyticsDelegate? = nil
 }


### PR DESCRIPTION
## Changes

- Added public delegate for analytics
- Fixed missed playback data
- Fixed empty event time
- Added notes to documentation
- ...

## Example of analytic logs

Raw message Serialized in protobuf format
```
"Event: \"pause\"\nVideo {\n  Source: \"https://kinescope.io/46f29c12-2eee-4596-90c4-42e03816c735/master.m3u8?expires=1712143455&token=\"\n  Duration: 3139\n}\nPlayer {\n  Type: \"iOS SDK\"\n  Version: \"0.2.0\"\n}\nDevice {\n  OS: \"iOS\"\n  OSVersion: \"17.4\"\n  ScreenWidth: 1179\n  ScreenHeight: 2556\n}\nSession {\n  ID: \"CA2932E2-B4BD-4829-A1C5-E1120D044496\"\n  ViewID: \"B09EF28A-768F-4DAE-971B-67584CF22139\"\n  WatchedDuration: 3\n}\nPlayback {\n  Rate: 1.0\n  Volume: 100\n  Quality: \"Auto\"\n  PreviewPosition: 76\n  CurrentPosition: 3\n}\nEventTime {\n  seconds: 1712057059\n  nanos: 553125978\n}\n"
```

## How to test?

- Check logs in Example project
