### PR TITLE
Fix live-translation in looped strategy with partially disabled UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.2.2
+
+### Added
+
+- Additional parameter for `KinescopePlayerConfig` to set up repeating attempts count for video loading
+
+### Fixed
+
+- Observation of preview/loading/playing status for player config with `looped` enabled
+
+
 ## 0.2.1
 
 ### Fixed bugs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 - Additional parameter for `KinescopePlayerConfig` to set up repeating attempts count for video loading
 
+### Changed
+
+- Indication of any pauses during playing of video with loading indicator
+
 ### Fixed
 
 - Observation of preview/loading/playing status for player config with `looped` enabled
-
+- Restoration of playback after network or stream lost
 
 ## 0.2.1
 

--- a/Example/KinescopeExample/Flows/EnterViewController.swift
+++ b/Example/KinescopeExample/Flows/EnterViewController.swift
@@ -12,6 +12,7 @@ final class EnterViewController: UIViewController {
     // MARK: - IBOutlets
 
     @IBOutlet weak var field: UITextField!
+    @IBOutlet weak var uiSwitch: UISwitch!
 
     // MARK: - Private properties
 
@@ -39,6 +40,7 @@ final class EnterViewController: UIViewController {
             return
         }
         destination.videoId = videoId
+        destination.uiEnabled = uiSwitch.isOn
     }
 
     // MARK: - Actions

--- a/Example/KinescopeExample/Flows/VideoViewController.swift
+++ b/Example/KinescopeExample/Flows/VideoViewController.swift
@@ -58,8 +58,9 @@ final class VideoViewController: UIViewController {
         
         let repeatingMode: RepeatingMode = uiEnabled ? .default : .infinite(interval: .seconds(5))
 
-        player = KinescopeVideoPlayer(config: .init(videoId: videoId, looped: !uiEnabled),
-                                      repeatingMode: repeatingMode)
+        player = KinescopeVideoPlayer(config: .init(videoId: videoId,
+                                                    looped: !uiEnabled,
+                                                    repeatingMode: repeatingMode))
 
         if #available(iOS 13.0, *) {
             if let shareIcon = UIImage(systemName: "square.and.arrow.up")?.withRenderingMode(.alwaysTemplate) {

--- a/Example/KinescopeExample/Flows/VideoViewController.swift
+++ b/Example/KinescopeExample/Flows/VideoViewController.swift
@@ -58,7 +58,7 @@ final class VideoViewController: UIViewController {
         
         let repeatingMode: RepeatingMode = uiEnabled ? .default : .infinite(interval: .seconds(5))
 
-        player = KinescopeVideoPlayer(config: .init(videoId: videoId),
+        player = KinescopeVideoPlayer(config: .init(videoId: videoId, looped: !uiEnabled),
                                       repeatingMode: repeatingMode)
 
         if #available(iOS 13.0, *) {

--- a/Example/KinescopeExample/Flows/VideoViewController.swift
+++ b/Example/KinescopeExample/Flows/VideoViewController.swift
@@ -20,6 +20,7 @@ final class VideoViewController: UIViewController {
     // MARK: - Public Properties
 
     var videoId: String = ""
+    var uiEnabled: Bool = true
 
     // MARK: - Appearance
 
@@ -41,7 +42,17 @@ final class VideoViewController: UIViewController {
 
         navigationController?.delegate = self
 
-        playerView.setLayout(with: .accentTimeLineAndPlayButton(with: .orange))
+        if uiEnabled {
+            playerView.setLayout(with: .accentTimeLineAndPlayButton(with: .orange))
+        } else {
+            playerView.setLayout(with: .builder()
+                .setGravity(.resizeAspect)
+                .setOverlay(nil)
+                .setControlPanel(nil)
+                .setShadowOverlay(nil)
+                .build()
+            )
+        }
 
         PipManager.shared.closePipIfNeeded(with: videoId)
 
@@ -53,7 +64,7 @@ final class VideoViewController: UIViewController {
             }
         }
         player?.disableOptions([.airPlay])
-        
+
         player?.setDelegate(delegate: self)
         player?.attach(view: playerView)
         player?.play()

--- a/Example/KinescopeExample/Flows/VideoViewController.swift
+++ b/Example/KinescopeExample/Flows/VideoViewController.swift
@@ -55,8 +55,11 @@ final class VideoViewController: UIViewController {
         }
 
         PipManager.shared.closePipIfNeeded(with: videoId)
+        
+        let repeatingMode: RepeatingMode = uiEnabled ? .default : .infinite(interval: .seconds(5))
 
-        player = KinescopeVideoPlayer(config: .init(videoId: videoId))
+        player = KinescopeVideoPlayer(config: .init(videoId: videoId),
+                                      repeatingMode: repeatingMode)
 
         if #available(iOS 13.0, *) {
             if let shareIcon = UIImage(systemName: "square.and.arrow.up")?.withRenderingMode(.alwaysTemplate) {

--- a/Example/KinescopeExample/Main.storyboard
+++ b/Example/KinescopeExample/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -47,6 +47,15 @@
                                     <action selector="didTapPlay:" destination="8D4-Vc-teG" eventType="touchUpInside" id="294-NJ-Nxf"/>
                                 </connections>
                             </button>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" toolTip="UIenabled" on="YES" title="UIEnabled" translatesAutoresizingMaskIntoConstraints="NO" id="UvK-HX-Vij">
+                                <rect key="frame" x="333" y="119" width="51" height="31"/>
+                            </switch>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Player UI Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GBg-RZ-G5U">
+                                <rect key="frame" x="32" y="124" width="133" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="B0s-tH-pXr"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -55,12 +64,17 @@
                             <constraint firstItem="wFE-5t-BHg" firstAttribute="leading" secondItem="824-rl-9c7" secondAttribute="trailing" constant="16" id="3UH-DD-ebf"/>
                             <constraint firstItem="B0s-tH-pXr" firstAttribute="trailing" secondItem="wFE-5t-BHg" secondAttribute="trailing" constant="32" id="Q0Q-Z3-4Qa"/>
                             <constraint firstItem="824-rl-9c7" firstAttribute="centerY" secondItem="B0s-tH-pXr" secondAttribute="centerY" id="RUx-cK-SEW"/>
+                            <constraint firstItem="GBg-RZ-G5U" firstAttribute="top" secondItem="B0s-tH-pXr" secondAttribute="top" constant="32" id="czb-OU-4cc"/>
+                            <constraint firstItem="GBg-RZ-G5U" firstAttribute="centerY" secondItem="UvK-HX-Vij" secondAttribute="centerY" id="dO0-Jh-lBc"/>
                             <constraint firstItem="824-rl-9c7" firstAttribute="leading" secondItem="B0s-tH-pXr" secondAttribute="leading" constant="32" id="hlL-b6-GO7"/>
+                            <constraint firstItem="B0s-tH-pXr" firstAttribute="trailing" secondItem="UvK-HX-Vij" secondAttribute="trailing" constant="32" id="jRX-CV-bMY"/>
+                            <constraint firstItem="GBg-RZ-G5U" firstAttribute="leading" secondItem="B0s-tH-pXr" secondAttribute="leading" constant="32" id="upc-AS-fSj"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="ktQ-3P-CGU"/>
                     <connections>
                         <outlet property="field" destination="824-rl-9c7" id="xA8-F2-XZs"/>
+                        <outlet property="uiSwitch" destination="UvK-HX-Vij" id="fxt-42-DgF"/>
                         <segue destination="DPB-hC-LdC" kind="show" identifier="Player" id="Ccv-TT-Kwb"/>
                     </connections>
                 </viewController>

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - KinescopeSDK (0.2.1):
+  - KinescopeSDK (0.2.2):
     - M3U8Kit (~> 1.0)
     - SwiftProtobuf (= 1.26.0)
   - M3U8Kit (1.0.2)
@@ -18,7 +18,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  KinescopeSDK: 46658fde8178bf17feec2c8b24ce2f74ea751be9
+  KinescopeSDK: ea5459195c0d371a45e75b0b09c25e145a1e2fad
   M3U8Kit: 6a0d55ba2e62e146f34f53276d7c3aa78ed4fc00
   SwiftProtobuf: 5e8349171e7c2f88f5b9e683cb3cb79d1dc780b3
 

--- a/KinescopeSDK.podspec
+++ b/KinescopeSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "KinescopeSDK"
-  s.version = "0.2.1"
+  s.version = "0.2.2"
   s.summary = "Library to help you include Kinescope player into your mobile iOS application"
   s.homepage = "https://github.com/kinescope/ios-kinescope-player"
   s.license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kinescope iOS SDK
 
-![Pub Version](https://img.shields.io/badge/version-0.2.1-orange)
+![Pub Version](https://img.shields.io/badge/version-0.2.2-orange)
 
 This framework created to help you include [Kinescope](https://kinescope.io/) player into your mobile iOS application.
 

--- a/Sources/KinescopeSDK/Bags/KVO/KVOSubKey.swift
+++ b/Sources/KinescopeSDK/Bags/KVO/KVOSubKey.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum KVOSubKey {
     case playerStatus
+    case playerItem
     case playerItemStatus
     case playerTimeControlStatus
 }

--- a/Sources/KinescopeSDK/Bags/KVO/KVOSubKey.swift
+++ b/Sources/KinescopeSDK/Bags/KVO/KVOSubKey.swift
@@ -10,6 +10,7 @@ import Foundation
 enum KVOSubKey {
     case playerStatus
     case playerItem
+    case playerItemBufferEmpty
     case playerItemStatus
     case playerTimeControlStatus
 }

--- a/Sources/KinescopeSDK/Bags/Notification/NotificationSubKey.swift
+++ b/Sources/KinescopeSDK/Bags/Notification/NotificationSubKey.swift
@@ -15,6 +15,7 @@ enum NotificationSubKey {
     case appDidEnterBackground
     case deviceOrientationChanged
     case itemDidPlayToEnd
+    case itemFailedToPlayToEndTime
 
     var notificationName: NSNotification.Name {
         switch self {
@@ -26,6 +27,8 @@ enum NotificationSubKey {
             return UIDevice.orientationDidChangeNotification
         case .itemDidPlayToEnd:
             return AVPlayerItem.didPlayToEndTimeNotification
+        case .itemFailedToPlayToEndTime:
+            return AVPlayerItem.failedToPlayToEndTimeNotification
         }
     }
 

--- a/Sources/KinescopeSDK/Models/KinescopePlayerConfig.swift
+++ b/Sources/KinescopeSDK/Models/KinescopePlayerConfig.swift
@@ -16,6 +16,9 @@ public struct KinescopePlayerConfig {
     /// If value is `true` show video in infinite loop.
     public let looped: Bool
     
+    /// Repeating mode for player
+    public let repeatingMode: RepeatingMode
+
     /// Default link to share video and play it on web.
     public var shareLink: URL? {
         URL(string: "https://kinescope.io/\(videoId)")
@@ -23,9 +26,11 @@ public struct KinescopePlayerConfig {
 
     /// - parameter videoId: Id of concrete video. For example from [GET Videos list](https://documenter.getpostman.com/view/10589901/TVCcXpNM)
     /// - parameter looped: If value is `true` show video in infinite loop. By default is `false`
-    public init(videoId: String, looped: Bool = false) {
+    /// - parameter repeatingMode: Mode which will be used to repeat failed requests.
+    public init(videoId: String, looped: Bool = false, repeatingMode: RepeatingMode = .default) {
         self.videoId = videoId
         self.looped = looped
+        self.repeatingMode = repeatingMode
     }
 
 }

--- a/Sources/KinescopeSDK/Player/KinescopeVideoPlayer.swift
+++ b/Sources/KinescopeSDK/Player/KinescopeVideoPlayer.swift
@@ -190,6 +190,8 @@ public class KinescopeVideoPlayer: KinescopePlayer, KinescopePlayerBody, Fullscr
         observePlaybackTime()
         addPlayerTimeControlStatusObserver()
         addPlayerStatusObserver()
+        addPlayerItemObserver()
+        addPlayerStatusObserver()
     }
 
     public func detach(view: KinescopePlayerView) {
@@ -206,16 +208,12 @@ public class KinescopeVideoPlayer: KinescopePlayer, KinescopePlayerBody, Fullscr
 
         savedTime = strategy.player.currentTime()
 
-        kvoBag.removeObserver(for: .playerItemStatus)
-
         if let item = quality.makeItem(with: drmHandler) {
             strategy.bind(item: item)
         }
 
         // changing quality
         strategy.player.currentItem?.preferredPeakBitRate = quality.preferredMaxBitRate
-
-        addPlayerItemStatusObserver()
     }
 
     public func setDelegate(delegate: KinescopeVideoPlayerDelegate) {
@@ -324,6 +322,17 @@ private extension KinescopeVideoPlayer {
         let observerFactory = PlayerStatusObserver(playerBody: self, 
                                                    repeater: $playRepeater)
         kvoBag.addObserver(for: .playerStatus, using: .init(wrappedFactory: observerFactory))
+    }
+    
+    func addPlayerItemObserver() {
+        let observerFactory = CurrentItemObserver(playerBody: self, currentItemChanged: {
+            [weak self] item in
+            self?.kvoBag.removeObserver(for: .playerItemStatus)
+            if let item {
+                self?.addPlayerItemStatusObserver()
+            }
+        })
+        kvoBag.addObserver(for: .playerItem, using: .init(wrappedFactory: observerFactory))
     }
 
     func addPlayerItemStatusObserver() {

--- a/Sources/KinescopeSDK/Player/KinescopeVideoPlayer.swift
+++ b/Sources/KinescopeSDK/Player/KinescopeVideoPlayer.swift
@@ -122,11 +122,10 @@ public class KinescopeVideoPlayer: KinescopePlayer, KinescopePlayerBody, Fullscr
 
     // MARK: - Lifecycle
 
-    init(config: KinescopePlayerConfig, 
-         repeatingMode: RepeatingMode,
+    init(config: KinescopePlayerConfig,
          dependencies: KinescopePlayerDependencies) {
         self.dependencies = dependencies
-        self._playRepeater = Repeating(executionQueue: .main, mode: repeatingMode)
+        self._playRepeater = Repeating(executionQueue: .main, mode: config.repeatingMode)
         self.config = config
         playRepeater = .init(title: "play") { [weak self] in self?.play() }
         addNotofications()
@@ -140,9 +139,8 @@ public class KinescopeVideoPlayer: KinescopePlayer, KinescopePlayerBody, Fullscr
 
     // MARK: - KinescopePlayer
 
-    public required convenience init(config: KinescopePlayerConfig, repeatingMode: RepeatingMode) {
+    public required convenience init(config: KinescopePlayerConfig) {
         self.init(config: config,
-                  repeatingMode: repeatingMode,
                   dependencies: KinescopeVideoPlayerDependencies())
         self.configureAnalytic()
     }

--- a/Sources/KinescopeSDK/Player/KinescopeVideoPlayer.swift
+++ b/Sources/KinescopeSDK/Player/KinescopeVideoPlayer.swift
@@ -29,7 +29,7 @@ public class KinescopeVideoPlayer: KinescopePlayer, KinescopePlayerBody, Fullscr
 
     private lazy var notificationsBag = NotificationsBag(observer: self)
     
-    @Repeating(executionQueue: .main, attemptsLimit: 10, intervalSeconds: 5)
+    @Repeating(executionQueue: .main, mode: .default)
     private var playRepeater
 
     private(set) lazy var strategy: PlayingStrategy = {
@@ -122,8 +122,11 @@ public class KinescopeVideoPlayer: KinescopePlayer, KinescopePlayerBody, Fullscr
 
     // MARK: - Lifecycle
 
-    init(config: KinescopePlayerConfig, dependencies: KinescopePlayerDependencies) {
+    init(config: KinescopePlayerConfig, 
+         repeatingMode: RepeatingMode,
+         dependencies: KinescopePlayerDependencies) {
         self.dependencies = dependencies
+        self._playRepeater = Repeating(executionQueue: .main, mode: repeatingMode)
         self.config = config
         playRepeater = .init(title: "play") { [weak self] in self?.play() }
         addNotofications()
@@ -137,8 +140,10 @@ public class KinescopeVideoPlayer: KinescopePlayer, KinescopePlayerBody, Fullscr
 
     // MARK: - KinescopePlayer
 
-    public required convenience init(config: KinescopePlayerConfig) {
-        self.init(config: config, dependencies: KinescopeVideoPlayerDependencies())
+    public required convenience init(config: KinescopePlayerConfig, repeatingMode: RepeatingMode) {
+        self.init(config: config,
+                  repeatingMode: repeatingMode,
+                  dependencies: KinescopeVideoPlayerDependencies())
         self.configureAnalytic()
     }
 

--- a/Sources/KinescopeSDK/Player/Observers/CurrentItemObserver.swift
+++ b/Sources/KinescopeSDK/Player/Observers/CurrentItemObserver.swift
@@ -1,0 +1,38 @@
+//
+//  CurrentItemObserver.swift
+//  KinescopeSDK
+//
+//  Created by Nikita Korobeinikov on 16.06.2024.
+//
+
+import Foundation
+import AVFoundation
+
+final class CurrentItemObserver: KVOObserverFactory {
+    
+    private weak var playerBody: KinescopePlayerBody?
+    
+    private var currentItemChanged: (AVPlayerItem?) -> Void
+
+    init(playerBody: KinescopePlayerBody,
+         currentItemChanged: @escaping (AVPlayerItem?) -> Void) {
+        self.playerBody = playerBody
+        self.currentItemChanged = currentItemChanged
+    }
+
+    func provide() -> NSKeyValueObservation? {
+        playerBody?.strategy.player.observe(
+            \.currentItem,
+            options: [.new, .old],
+            changeHandler: { [weak self] item, _ in
+                self?.currentItemChanged(item.currentItem)
+
+                Kinescope.shared.logger?.log(
+                    message: "AVPlayer.CurrentItem – \(item.currentItem.debugDescription)",
+                    level: KinescopeLoggerLevel.player
+                )
+            }
+        )
+    }
+
+}

--- a/Sources/KinescopeSDK/Player/Observers/EmptyBufferObserver.swift
+++ b/Sources/KinescopeSDK/Player/Observers/EmptyBufferObserver.swift
@@ -1,0 +1,41 @@
+//
+//  EmptyBufferObserver.swift
+//  KinescopeSDK
+//
+//  Created by Nikita Korobeinikov on 24.06.2024.
+//
+
+import Foundation
+import AVFoundation
+
+final class EmptyBufferObserver: KVOObserverFactory {
+
+    private weak var playerBody: KinescopePlayerBody?
+    private weak var repeater: Repeater?
+
+    init(playerBody: KinescopePlayerBody,
+         repeater: Repeater) {
+        self.repeater = repeater
+        self.playerBody = playerBody
+    }
+
+    func provide() -> NSKeyValueObservation? {
+        playerBody?.strategy.player.currentItem?.observe(
+            \.isPlaybackBufferEmpty,
+            options: [.new, .old],
+            changeHandler: { [weak self] item, value in
+                let isBufferEmpty = value.newValue ?? item.isPlaybackBufferEmpty
+                if isBufferEmpty {
+                    self?.repeater?.start()
+                }
+
+                Kinescope.shared.logger?.log(
+                    message: "AVPlayer.isPlaybackBufferEmpty – \(isBufferEmpty)",
+                    level: KinescopeLoggerLevel.player
+                )
+            }
+        )
+    }
+
+}
+

--- a/Sources/KinescopeSDK/Protocols/KinescopePlayer.swift
+++ b/Sources/KinescopeSDK/Protocols/KinescopePlayer.swift
@@ -18,7 +18,8 @@ public protocol KinescopePlayer {
     var pipDelegate: AVPictureInPictureControllerDelegate? { get set }
 
     /// - parameter config: player config
-    init(config: KinescopePlayerConfig)
+    /// - parameter repeatingMode: repeating mode for player
+    init(config: KinescopePlayerConfig, repeatingMode: RepeatingMode)
 
     /// Start playing of video
     func play()

--- a/Sources/KinescopeSDK/Protocols/KinescopePlayer.swift
+++ b/Sources/KinescopeSDK/Protocols/KinescopePlayer.swift
@@ -18,8 +18,7 @@ public protocol KinescopePlayer {
     var pipDelegate: AVPictureInPictureControllerDelegate? { get set }
 
     /// - parameter config: player config
-    /// - parameter repeatingMode: repeating mode for player
-    init(config: KinescopePlayerConfig, repeatingMode: RepeatingMode)
+    init(config: KinescopePlayerConfig)
 
     /// Start playing of video
     func play()

--- a/Sources/KinescopeSDK/View/Player/KinescopePlayerView.swift
+++ b/Sources/KinescopeSDK/View/Player/KinescopePlayerView.swift
@@ -86,8 +86,11 @@ public class KinescopePlayerView: UIView {
             overlay?.isHidden = false
             overlay?.set(playing: true)
             progressView.showVideoProgress(isLoading: false)
-        case .paused, .waitingToPlayAtSpecifiedRate:
+        case .paused:
             overlay?.set(playing: false)
+        case .waitingToPlayAtSpecifiedRate:
+            overlay?.set(playing: false)
+            progressView.showVideoProgress(isLoading: true)
         @unknown default:
             break
         }

--- a/Sources/Podfile
+++ b/Sources/Podfile
@@ -8,5 +8,6 @@ target 'KinescopeSDK' do
 
   # Pods for KinescopeSDK
   pod 'SwiftProtobuf', '~> 1.0'
+  pod 'M3U8Kit', '~> 1.0'
 
 end

--- a/Sources/Podfile.lock
+++ b/Sources/Podfile.lock
@@ -1,16 +1,21 @@
 PODS:
+  - M3U8Kit (1.0.2)
   - SwiftProtobuf (1.16.0)
 
 DEPENDENCIES:
+  - M3U8Kit (~> 1.0)
   - SwiftProtobuf (~> 1.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - SwiftProtobuf
+  trunk:
+    - M3U8Kit
 
 SPEC CHECKSUMS:
+  M3U8Kit: 6a0d55ba2e62e146f34f53276d7c3aa78ed4fc00
   SwiftProtobuf: 4e16842b83c6fda06b10fac50d73b3f1fce8ab7b
 
-PODFILE CHECKSUM: c2dda49b4bff3b9bc41ca4197753ace3179f31af
+PODFILE CHECKSUM: a2fe72733d714251cc457b0b73f9a72963a52d5f
 
 COCOAPODS: 1.10.2


### PR DESCRIPTION
## Changes

- Added switch option to may test two configurations in Example project
- Added settings for repeating mode
- Fixed observation of currentItem while using looped strategy
- ...

## How to test?

- Open example
- Turn off switch "Player UI Enabled"
- Replace id with any videoId or translation id
- Play
