### PR TITLE
Fix option buttons not firing in embedded/hosted view hierarchies

### DIFF
--- a/Sources/KinescopeSDK/View/Player/Layout/PlayerControlOptionsView.swift
+++ b/Sources/KinescopeSDK/View/Player/Layout/PlayerControlOptionsView.swift
@@ -134,7 +134,7 @@ private extension PlayerControlOptionsView {
             button.tintColor = config.normalColor
             button.squareSize(with: config.iconSize)
 
-            button.addTarget(nil, action: #selector(buttonTapped(sender:)), for: .touchUpInside)
+            button.addTarget(self, action: #selector(buttonTapped(sender:)), for: .touchUpInside)
 
             return button
         }


### PR DESCRIPTION
This PR fixes option buttons (fullscreen / more / custom options) not firing actions in some embed scenarios (e.g. UIKit view hosted inside Compose Multiplatform interop). The buttons visually highlight on tap, but no event is delivered because the target is set to nil and relies on the responder chain. In non-standard hosting environments the responder chain may not contain an object that responds to the selector, so the action never reaches PlayerControlOptionsView.

Changing addTarget(nil, ...) to addTarget(self, ...) makes the action delivery deterministic and restores expected behavior for all option buttons, without affecting play/pause/seek controls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes option button actions not triggering in embedded/hosted view hierarchies by explicitly targeting the control.
> 
> - In `PlayerControlOptionsView.swift`, change `button.addTarget(nil, ...)` to `button.addTarget(self, ...)` for non-AirPlay option buttons to ensure tap events are delivered deterministically
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50069c68a9d1244727046902861e871ca3f05a14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->