### PR TITLE
Fix prevent crash with a single option

### DIFF
--- a/Sources/KinescopeSDK/View/Player/Layout/PlayerControlOptionsView.swift
+++ b/Sources/KinescopeSDK/View/Player/Layout/PlayerControlOptionsView.swift
@@ -142,15 +142,19 @@ private extension PlayerControlOptionsView {
 
     func fillStack(with options: [KinescopePlayerOption], expanded: Bool) {
         guard !options.isEmpty else {
+            clearStack()
             return
         }
-
+    
         clearStack()
-
-        let filteredOptions = expanded
-            ? options
-            : Array(options.dropFirst(options.count - 2))
-
+    
+        let filteredOptions: [KinescopePlayerOption]
+        if expanded || options.count <= 2 {
+            filteredOptions = options
+        } else {
+            filteredOptions = Array(options.suffix(2))
+        }
+    
         filteredOptions
             .enumerated()
             .map { index, option in
@@ -159,7 +163,7 @@ private extension PlayerControlOptionsView {
             .forEach { [weak self] button in
                 self?.stackView.addArrangedSubview(button)
             }
-
+    
         set(subtitleOn: isSubtitleOn)
     }
 

--- a/Sources/KinescopeSDK/View/Player/Layout/PlayerControlOptionsView.swift
+++ b/Sources/KinescopeSDK/View/Player/Layout/PlayerControlOptionsView.swift
@@ -142,7 +142,6 @@ private extension PlayerControlOptionsView {
 
     func fillStack(with options: [KinescopePlayerOption], expanded: Bool) {
         guard !options.isEmpty else {
-            clearStack()
             return
         }
     


### PR DESCRIPTION
When expanded == false the code uses dropFirst(options.count - 2). If options.count == 1, this becomes dropFirst(-1) and triggers a runtime precondition failure.
Fix: if options.count <= 2, show all options; otherwise show the last two via suffix(2).

1. Disable all built-in options and leave exactly one option (e.g., only one custom option).
2. Ensure the options view is in the collapsed state (expanded == false).
3. Observe: the app crashes due to dropFirst(options.count - 2) evaluating to dropFirst(-1) when options.count == 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents a runtime crash in `PlayerControlOptionsView` when the options list has one item and the view is collapsed.
> 
> - In `fillStack` (PlayerControlOptionsView.swift), replaces `dropFirst(options.count - 2)` with a conditional: show all options when `expanded` or `options.count <= 2`, else show the last two via `suffix(2)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fab4668d43b82130c64b90ac55fe611da868a470. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->